### PR TITLE
DEV-20260115-003: extend content schema for T2-T5

### DIFF
--- a/docs/CONTENT_SPEC.md
+++ b/docs/CONTENT_SPEC.md
@@ -1,0 +1,71 @@
+# 内容结构化规范（Content Spec，v1）
+
+目标：把 docx 复习资料整理成稳定的 JSON（content），供“题目生成器”随机出题。
+
+> 原则：MVP 允许半自动（脚本抽取 + 人工补齐），但 schema 必须稳定、可版本化。
+
+## 1. 顶层结构
+- `schemaVersion`：当前为 `1`
+- `subject/grade/term`：学科/年级/上下册
+- `units`：8 个单元（u1-u8）
+
+示例：
+```json
+{
+  "schemaVersion": 1,
+  "subject": "chinese",
+  "grade": 2,
+  "term": "up",
+  "units": []
+}
+```
+
+## 2. 单元 Unit
+```json
+{
+  "unitId": "u1",
+  "title": "第一单元",
+  "sections": []
+}
+```
+
+## 3. Section 类型（对应 5 大题型）
+
+### 3.1 `char_table`（T1 拼音认读）
+- items：`hanzi/pinyin/words`
+
+### 3.2 `word_disambiguation`（T2 字词辨析）
+- 支持三类 item（MVP 可先用其中一种）：
+  - `polyphone`：多音字（汉字 + 多个读音 + 例词）
+  - `syn_ant`：近义/反义词
+  - `confusing`：易混词辨析（手工配置型）
+
+### 3.3 `sentence_pattern`（T3 句子仿写）
+- `patterns[]`：句型模板集合
+- 每个 pattern：
+  - `template`：带 slot 的模板（如 `{a}一边{v1}，一边{v2}。`）
+  - `slots`：槽位定义
+  - `wordBank`：每个 slot 的词库
+
+### 3.4 `poem`（T4 古诗背诵）
+- `poems[]`：诗词
+- 每首诗：`title/author/lines[]`
+
+### 3.5 `reading_comprehension`（T5 课文理解）
+- `passages[]`：阅读材料
+- 每篇 passage：`text + questions[]`
+- 题型：
+  - `mcq`：选择题
+  - `true_false`：判断题
+
+## 4. 与“普通关卡 / Boss关卡”的关系
+- 普通关卡（u1）：T1/T2/T3 的 section 为主
+- Boss 关卡（u1）：T4/T5 的 section 为主
+
+工程上建议：同一个 unit 里允许同时存在 5 类 section，运行时按关卡类型（普通/Boss）选择不同的题型来源。
+
+## 5. 生成与维护方式（MVP）
+- T1：可通过脚本从 docx 表格抽取（已有 `tools/extract_char_table.py`）
+- T2/T3/T4/T5：
+  - 优先：从 docx 对应段落/表格抽取
+  - 兜底：手工整理成 JSON（先跑起来），后续老师端再提升自动化

--- a/src/content/content.v1.json
+++ b/src/content/content.v1.json
@@ -26,6 +26,132 @@
             { "itemId": "u1.s1.0011", "hanzi": "帕", "pinyin": "pà", "words": ["手帕"] },
             { "itemId": "u1.s1.0012", "hanzi": "登", "pinyin": "dēng", "words": ["登山", "登记"] }
           ]
+        },
+        {
+          "sectionId": "u1.s2",
+          "type": "word_disambiguation",
+          "title": "多音字/近反义词（样例）",
+          "items": [
+            {
+              "itemId": "u1.s2.0001",
+              "kind": "polyphone",
+              "hanzi": "教",
+              "options": [
+                { "pinyin": "jiāo", "example": "教书" },
+                { "pinyin": "jiào", "example": "教室" }
+              ]
+            },
+            {
+              "itemId": "u1.s2.0002",
+              "kind": "polyphone",
+              "hanzi": "种",
+              "options": [
+                { "pinyin": "zhǒng", "example": "种类" },
+                { "pinyin": "zhòng", "example": "种地" }
+              ]
+            },
+            {
+              "itemId": "u1.s2.0003",
+              "kind": "syn_ant",
+              "word": "快活",
+              "synonym": "快乐",
+              "antonym": "难过"
+            }
+          ]
+        },
+        {
+          "sectionId": "u1.s3",
+          "type": "sentence_pattern",
+          "title": "句子仿写（模板）",
+          "patterns": [
+            {
+              "patternId": "u1.p1",
+              "name": "有时候……有时候……",
+              "template": "有时候{a}，有时候{b}。",
+              "slots": [
+                { "key": "a", "label": "情况A" },
+                { "key": "b", "label": "情况B" }
+              ],
+              "wordBank": {
+                "a": ["我变成小硬球打下来", "太阳躲到云后面"],
+                "b": ["我变成小花朵飘下来", "天空又放晴了"]
+              }
+            },
+            {
+              "patternId": "u1.p2",
+              "name": "只要……就……",
+              "template": "只要{a}，就{b}。",
+              "slots": [
+                { "key": "a", "label": "条件" },
+                { "key": "b", "label": "结果" }
+              ],
+              "wordBank": {
+                "a": ["有风轻轻吹过", "秋风一吹"],
+                "b": ["孩子们就乘着风纷纷出发", "树叶就纷纷飘落下来"]
+              }
+            },
+            {
+              "patternId": "u1.p3",
+              "name": "一边……一边……",
+              "template": "{a}一边{v1}，一边{v2}。",
+              "slots": [
+                { "key": "a", "label": "主语" },
+                { "key": "v1", "label": "动作1" },
+                { "key": "v2", "label": "动作2" }
+              ],
+              "wordBank": {
+                "a": ["我", "小猫"],
+                "v1": ["写作业", "走路"],
+                "v2": ["听音乐", "看风景"]
+              }
+            }
+          ]
+        },
+        {
+          "sectionId": "u1.b1",
+          "type": "poem",
+          "title": "古诗二首（Boss）",
+          "poems": [
+            {
+              "poemId": "u1.poem1",
+              "title": "登鹳雀楼",
+              "author": "王之涣",
+              "lines": ["白日依山尽", "黄河入海流", "欲穷千里目", "更上一层楼"]
+            },
+            {
+              "poemId": "u1.poem2",
+              "title": "望庐山瀑布",
+              "author": "李白",
+              "lines": ["日照香炉生紫烟", "遥看瀑布挂前川", "飞流直下三千尺", "疑是银河落九天"]
+            }
+          ]
+        },
+        {
+          "sectionId": "u1.b2",
+          "type": "reading_comprehension",
+          "title": "课文理解（Boss样例）",
+          "passages": [
+            {
+              "passageId": "u1.read1",
+              "title": "阅读的乐趣（节选）",
+              "text": "阅读给我带来了许多乐趣。班会课上，老师给我们讲了一个很有趣的故事。",
+              "questions": [
+                {
+                  "questionId": "u1.read1.q1",
+                  "kind": "true_false",
+                  "prompt": "作者觉得阅读很有趣。",
+                  "answer": true
+                },
+                {
+                  "questionId": "u1.read1.q2",
+                  "kind": "mcq",
+                  "prompt": "故事发生在什么课上？",
+                  "choices": ["班会课", "体育课", "美术课", "音乐课"],
+                  "correctChoice": "班会课"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/src/domain/content/types.ts
+++ b/src/domain/content/types.ts
@@ -12,7 +12,12 @@ export type Unit = {
   sections: Section[];
 };
 
-export type Section = CharTableSection;
+export type Section =
+  | CharTableSection
+  | WordDisambiguationSection
+  | SentencePatternSection
+  | PoemSection
+  | ReadingComprehensionSection;
 
 export type CharTableSection = {
   sectionId: string;
@@ -30,4 +35,96 @@ export type CharItem = {
     doc: string;
     hint?: string;
   };
+};
+
+// T2 字词辨析（多音字 / 近反义词 / 易混词）
+export type WordDisambiguationSection = {
+  sectionId: string;
+  type: "word_disambiguation";
+  title: string;
+  items: Array<PolyphoneItem | SynAntItem | ConfusingWordsItem>;
+};
+
+export type PolyphoneItem = {
+  itemId: string;
+  kind: "polyphone";
+  hanzi: string; // e.g. 教
+  options: Array<{ pinyin: string; example: string }>; // e.g. 教书 / 教室
+};
+
+export type SynAntItem = {
+  itemId: string;
+  kind: "syn_ant";
+  word: string;
+  synonym?: string;
+  antonym?: string;
+};
+
+export type ConfusingWordsItem = {
+  itemId: string;
+  kind: "confusing";
+  prompt: string;
+  correct: string;
+  distractors: string[];
+};
+
+// T3 句子仿写（模板 + 词库）
+export type SentencePatternSection = {
+  sectionId: string;
+  type: "sentence_pattern";
+  title: string;
+  patterns: SentencePattern[];
+};
+
+export type SentencePattern = {
+  patternId: string;
+  name: string; // e.g. 一边…一边…
+  template: string; // e.g. "{a}一边{v1}，一边{v2}。"
+  slots: Array<{ key: string; label: string }>; // e.g. a/v1/v2
+  wordBank: Record<string, string[]>; // per slot key
+};
+
+// T4 古诗背诵
+export type PoemSection = {
+  sectionId: string;
+  type: "poem";
+  title: string;
+  poems: Poem[];
+};
+
+export type Poem = {
+  poemId: string;
+  title: string;
+  author: string;
+  lines: string[];
+};
+
+// T5 课文理解（选择/判断）
+export type ReadingComprehensionSection = {
+  sectionId: string;
+  type: "reading_comprehension";
+  title: string;
+  passages: Passage[];
+};
+
+export type Passage = {
+  passageId: string;
+  title: string;
+  text: string;
+  questions: Array<ReadingMcq | ReadingTrueFalse>;
+};
+
+export type ReadingMcq = {
+  questionId: string;
+  kind: "mcq";
+  prompt: string;
+  choices: string[];
+  correctChoice: string;
+};
+
+export type ReadingTrueFalse = {
+  questionId: string;
+  kind: "true_false";
+  prompt: string;
+  answer: boolean;
 };

--- a/src/domain/questions/generate.ts
+++ b/src/domain/questions/generate.ts
@@ -17,9 +17,10 @@ export function generateRun(
   const unit = content.units.find((u) => u.unitId === options.unitId);
   if (!unit) throw new Error(`Unknown unitId: ${options.unitId}`);
 
-  const items: CharItem[] = unit.sections
-    .filter((s) => s.type === "char_table")
-    .flatMap((s) => s.items);
+  const items: CharItem[] = unit.sections.flatMap((s) => {
+    if (s.type !== "char_table") return [];
+    return s.items;
+  });
 
   if (items.length < options.questionCount) {
     throw new Error(


### PR DESCRIPTION
 扩展 content schema 支持 T2/T3/T4/T5：zooquest-web/src/domain/content/types.ts
Unit1 增加 T2/T3/T4/T5 最小样例数据：zooquest-web/src/content/content.v1.json
增加中文内容规范：zooquest-web/docs/CONTENT_SPEC.md
为 schema union 做了生成器类型收敛兼容（不涉及新题型实现）：zooquest-web/src/domain/questions/generate.tssentence patterns, poems, and reading comprehension, plus Unit1 sample content.