### PR TITLE
DEV-20260115-004｜勋章体系：普通+Boss+坚持

### DIFF
--- a/src/app/api/run/start/route.ts
+++ b/src/app/api/run/start/route.ts
@@ -9,7 +9,7 @@ import { getContent } from "@/infra/content/localContent";
 import { generateRun } from "@/domain/questions/generate";
 
 const bodySchema = z.object({
-  unitId: z.string().min(1).max(16),
+  unitId: z.string().regex(/^u[1-8]$/),
 });
 
 export async function POST(req: Request) {

--- a/src/domain/badges/rules.ts
+++ b/src/domain/badges/rules.ts
@@ -1,28 +1,36 @@
-import type { BadgeAward, BadgeContext, BadgeId } from "@/domain/badges/types";
+import type { BadgeAward, BadgeContext, BadgeId, UnitId } from "@/domain/badges/types";
 
-const UNIT_CLEAR_BADGES: Record<string, BadgeId> = {
-  u1: "clear_u1",
-  u2: "clear_u2",
-  u3: "clear_u3",
-  u4: "clear_u4",
-  u5: "clear_u5",
-  u6: "clear_u6",
-  u7: "clear_u7",
-  u8: "clear_u8",
-};
+function clearBadgeId(unitId: UnitId): BadgeId {
+  return `clear_${unitId}`;
+}
+
+function star3BadgeId(unitId: UnitId): BadgeId {
+  return `star3_${unitId}`;
+}
+
+function bossClearBadgeId(unitId: UnitId): BadgeId {
+  return `boss_${unitId}_clear`;
+}
+
+function bossStar3BadgeId(unitId: UnitId): BadgeId {
+  return `boss_${unitId}_star3`;
+}
 
 export function computeBadgeAwards(ctx: BadgeContext): BadgeAward[] {
   const awards: BadgeAward[] = [];
 
-  if (ctx.passed) {
-    const clearBadge = UNIT_CLEAR_BADGES[ctx.unitId];
-    if (clearBadge) awards.push({ badgeId: clearBadge, reasonEvent: "RUN_PASSED" });
+  if (ctx.mode === "regular") {
+    if (ctx.stars >= 2) awards.push({ badgeId: clearBadgeId(ctx.unitId), reasonEvent: "REGULAR_CLEAR" });
+    if (ctx.stars === 3) awards.push({ badgeId: star3BadgeId(ctx.unitId), reasonEvent: "REGULAR_STAR3" });
+  } else {
+    if (ctx.stars >= 2) awards.push({ badgeId: bossClearBadgeId(ctx.unitId), reasonEvent: "BOSS_CLEAR" });
+    if (ctx.stars === 3) awards.push({ badgeId: bossStar3BadgeId(ctx.unitId), reasonEvent: "BOSS_STAR3" });
   }
 
   if (ctx.totalFailsAllUnits >= 10) {
-    awards.push({ badgeId: "persistence_10fails", reasonEvent: "FAILS_TOTAL_10" });
+    awards.push({ badgeId: "persistence_fails_10", reasonEvent: "FAILS_TOTAL_10" });
   } else if (ctx.totalFailsAllUnits >= 5) {
-    awards.push({ badgeId: "persistence_5fails", reasonEvent: "FAILS_TOTAL_5" });
+    awards.push({ badgeId: "persistence_fails_5", reasonEvent: "FAILS_TOTAL_5" });
   }
 
   return awards;

--- a/src/domain/badges/types.ts
+++ b/src/domain/badges/types.ts
@@ -1,14 +1,12 @@
+export type UnitId = `u${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`;
+
 export type BadgeId =
-  | "clear_u1"
-  | "clear_u2"
-  | "clear_u3"
-  | "clear_u4"
-  | "clear_u5"
-  | "clear_u6"
-  | "clear_u7"
-  | "clear_u8"
-  | "persistence_5fails"
-  | "persistence_10fails";
+  | `clear_${UnitId}`
+  | `star3_${UnitId}`
+  | `boss_${UnitId}_clear`
+  | `boss_${UnitId}_star3`
+  | "persistence_fails_5"
+  | "persistence_fails_10";
 
 export type BadgeAward = {
   badgeId: BadgeId;
@@ -16,7 +14,12 @@ export type BadgeAward = {
 };
 
 export type BadgeContext = {
-  unitId: string;
-  passed: boolean;
+  unitId: UnitId;
+  mode: "regular" | "boss";
+  stars: 0 | 1 | 2 | 3;
   totalFailsAllUnits: number;
 };
+
+export function isUnitId(value: string): value is UnitId {
+  return /^u[1-8]$/.test(value);
+}


### PR DESCRIPTION
## Summary
- 普通关与 Boss 关在结算时自动授予勋章：通关（⭐⭐）、完美（⭐⭐⭐）、坚持（累计失败）。
- 勋章通过 Supabase `badge_awards` 表 `upsert` 写入并去重，API 响应返回 `newBadges`。

## Changes
- `src/domain/badges/types.ts`：扩展 `BadgeId`（`clear_uX`/`star3_uX`/`boss_uX_clear`/`boss_uX_star3`/坚持类）并新增 `isUnitId`。
- `src/domain/badges/rules.ts`：基于 `mode + stars + totalFailsAllUnits` 计算勋章授予列表。
- `src/app/api/run/start/route.ts`：收紧 `unitId` 校验为 `u1-u8`。
- `src/app/api/run/finish/route.ts`：普通关结算接入勋章授予并返回 `newBadges`。
- `src/app/api/boss/run/finish/route.ts`：Boss 结算接入勋章授予并返回 `newBadges`。

## Verification
- `npm run lint`
- `npm run build`

Closes #4