### PR TITLE
DEV-20260115-007: 勋章墙接入 catalog（展示图标/名称）

### DIFF
--- a/public/badges/badge-placeholder.svg
+++ b/public/badges/badge-placeholder.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="badge placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4f4f5"/>
+      <stop offset="1" stop-color="#e4e4e7"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="224" height="224" rx="32" fill="url(#g)" stroke="#d4d4d8"/>
+  <circle cx="128" cy="110" r="44" fill="#fafafa" stroke="#d4d4d8"/>
+  <path d="M92 188c18-26 54-26 72 0" fill="none" stroke="#a1a1aa" stroke-width="10" stroke-linecap="round"/>
+  <path d="M112 108h32" stroke="#a1a1aa" stroke-width="10" stroke-linecap="round"/>
+  <text x="128" y="232" text-anchor="middle" font-family="system-ui, -apple-system, Segoe UI, Arial" font-size="14" fill="#71717a">Badge</text>
+</svg>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
+import { getBadgeMeta } from "@/domain/badges/catalog";
 import { LEVELS } from "@/domain/levels/levels";
 import { computeLevelState } from "@/domain/levels/state";
 
@@ -169,12 +170,34 @@ export function Dashboard(props: { nickname: string; onLogout: () => void }) {
           <div className="text-sm text-zinc-600">还没有勋章，先去闯一关吧。</div>
         ) : (
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            {badges.slice(0, 8).map((b) => (
-              <div key={b.badge_id} className="rounded-md border border-zinc-200 bg-white p-3">
-                <div className="text-sm font-medium">{b.badge_id}</div>
-                <div className="text-xs text-zinc-600">{new Date(b.awarded_at).toLocaleString()}</div>
-              </div>
-            ))}
+            {badges.slice(0, 8).map((b) => {
+              const meta = getBadgeMeta(b.badge_id);
+              return (
+                <div key={b.badge_id} className="rounded-md border border-zinc-200 bg-white p-3">
+                  <div className="flex items-start gap-3">
+                    <img
+                      src={meta.assetPath}
+                      alt={meta.name}
+                      className="h-10 w-10 shrink-0 rounded bg-zinc-50 object-contain"
+                      onError={(e) => {
+                        e.currentTarget.src = meta.fallbackAssetPath;
+                      }}
+                    />
+
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-black">{meta.name}</div>
+                      {meta.description ? (
+                        <div className="mt-1 text-xs text-zinc-600">{meta.description}</div>
+                      ) : null}
+                      <div className="mt-2 text-xs text-zinc-600">
+                        {new Date(b.awarded_at).toLocaleString()}
+                      </div>
+                      <div className="mt-1 text-[10px] text-zinc-400">{meta.badgeId}</div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/domain/badges/catalog.ts
+++ b/src/domain/badges/catalog.ts
@@ -1,0 +1,95 @@
+import { LEVELS } from "@/domain/levels/levels";
+
+export type BadgeMeta = {
+  badgeId: string;
+  name: string;
+  description: string;
+  assetPath: string;
+  fallbackAssetPath: string;
+};
+
+const FALLBACK_ASSET = "/badges/badge-placeholder.svg";
+
+export function getBadgeMeta(badgeId: string): BadgeMeta {
+  const assetPath = `/badges/badge-${badgeId}.png`;
+
+  if (badgeId === "persistence_fails_5") {
+    return {
+      badgeId,
+      name: "坚持不懈（5次）",
+      description: "累计失败 5 次，仍然继续挑战。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "persistence_fails_10") {
+    return {
+      badgeId,
+      name: "越挫越勇（10次）",
+      description: "累计失败 10 次，依然不放弃。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  const mClear = badgeId.match(/^clear_(u[1-8])$/);
+  if (mClear) {
+    const unitId = mClear[1]!;
+    const level = LEVELS.find((l) => l.unitId === unitId);
+    return {
+      badgeId,
+      name: `${level?.regionName ?? unitId}通关`,
+      description: "普通关达到 ⭐⭐。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  const mStar3 = badgeId.match(/^star3_(u[1-8])$/);
+  if (mStar3) {
+    const unitId = mStar3[1]!;
+    const level = LEVELS.find((l) => l.unitId === unitId);
+    return {
+      badgeId,
+      name: `${level?.regionName ?? unitId}完美通关`,
+      description: "普通关达到 ⭐⭐⭐。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  const mBossClear = badgeId.match(/^boss_(u[1-8])_clear$/);
+  if (mBossClear) {
+    const unitId = mBossClear[1]!;
+    const level = LEVELS.find((l) => l.unitId === unitId);
+    return {
+      badgeId,
+      name: `${level?.regionName ?? unitId}Boss通过`,
+      description: "Boss 关达到 ⭐⭐。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  const mBossStar3 = badgeId.match(/^boss_(u[1-8])_star3$/);
+  if (mBossStar3) {
+    const unitId = mBossStar3[1]!;
+    const level = LEVELS.find((l) => l.unitId === unitId);
+    return {
+      badgeId,
+      name: `${level?.regionName ?? unitId}Boss完美`,
+      description: "Boss 关达到 ⭐⭐⭐。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  return {
+    badgeId,
+    name: badgeId,
+    description: "",
+    assetPath,
+    fallbackAssetPath: FALLBACK_ASSET,
+  };
+}


### PR DESCRIPTION
## 背景
当前勋章墙仅展示 `badge_id`，不利于孩子理解与收集动机。

## 变更
- 新增 `getBadgeMeta(badgeId)`：为勋章提供中文名、描述、图标路径（含 fallback）
- 勋章墙改为展示：图标 + 中文名 + 描述（可选）+ 获得时间（保留 badge_id 作为小字）

## 说明
- 图标默认路径：`/badges/badge-{badgeId}.png`
- 如果图片不存在或加载失败，回退到：`/badges/badge-placeholder.svg`

Closes #13