### PR TITLE
DEV-20260115-008: add stage intro and wrong-answer review

### DIFF
--- a/src/app/api/run/check/route.ts
+++ b/src/app/api/run/check/route.ts
@@ -48,18 +48,18 @@ function buildExplanation(content: ContentSchemaV1, unitId: string, q: Question)
     }
 
     case "mcq_polyphone":
-      return `在“${q.example}”里，“${q.hanzi}”读“${q.correctChoice}”。`;
+      return `在“${q.example}”里，“${q.hanzi}”读“${q.correctChoice}”，注意看词语语境。`;
 
     case "mcq_syn_ant": {
       const word = q.prompt.match(/“(.+?)”/)?.[1];
-      if (q.prompt.includes("近义词") && word) return `“${word}”的近义词是“${q.correctChoice}”。`;
-      if (q.prompt.includes("反义词") && word) return `“${word}”的反义词是“${q.correctChoice}”。`;
+      if (q.prompt.includes("近义词") && word) return `“${word}”的近义词是“${q.correctChoice}”，意思相近。`;
+      if (q.prompt.includes("反义词") && word) return `“${word}”的反义词是“${q.correctChoice}”，意思相反。`;
       return `正确答案是“${q.correctChoice}”。`;
     }
 
     case "sentence_pattern_fill": {
       const preview = q.template.replace(/\{(.*?)\}/g, (_, key) => q.correct[key] ?? "____");
-      return `参考：${preview}`;
+      return `句型提示：照着句子结构填词。参考：${preview}`;
     }
   }
 }


### PR DESCRIPTION
阶段开场卡：zooquest-web/src/components/play/PlayClient.tsx
在第 1/3/5 题前出现（索引 0/2/4）
展示 Stage A/B/C + 任务一句话 + “开始”
可勾选“跳过后续开场”
错题回看强化：zooquest-web/src/components/play/PlayClient.tsx
结算页新增“错题回看”列表：题干、你的回答、正确答案、解析
数据来源：逐题判定时缓存的 feedbackByQuestionId（避免再次调用接口/不依赖 finish 返回额外字段）
解析文案更强一点：zooquest-web/src/app/api/run/check/route.ts
T2 多音字/近反义 & T3 句型补了更偏“为什么”的一句话