### PR TITLE
DEV-20260116-009: content schema v2 types + v1/v2 compatibility

### DIFF
--- a/src/app/api/run/check/route.ts
+++ b/src/app/api/run/check/route.ts
@@ -7,7 +7,7 @@ import { getContent } from "@/infra/content/localContent";
 import { generateRun } from "@/domain/questions/generate";
 import { gradeRun } from "@/domain/questions/grade";
 import type { Answer, Question } from "@/domain/questions/types";
-import type { ContentSchemaV1, CharItem } from "@/domain/content/types";
+import type { CharItem, ContentSchema } from "@/domain/content/types";
 
 const bodySchema = z.object({
   runId: z.string().uuid(),
@@ -16,7 +16,7 @@ const bodySchema = z.object({
   payload: z.unknown().optional(),
 });
 
-function getCharItems(content: ContentSchemaV1, unitId: string): CharItem[] {
+function getCharItems(content: ContentSchema, unitId: string): CharItem[] {
   const unit = content.units.find((u) => u.unitId === unitId);
   if (!unit) return [];
 
@@ -26,13 +26,13 @@ function getCharItems(content: ContentSchemaV1, unitId: string): CharItem[] {
   });
 }
 
-function pickWords(content: ContentSchemaV1, unitId: string, hanzi: string): string[] {
+function pickWords(content: ContentSchema, unitId: string, hanzi: string): string[] {
   const chars = getCharItems(content, unitId);
   const item = chars.find((c) => c.hanzi === hanzi);
   return (item?.words ?? []).filter((w) => w.length > 0).slice(0, 2);
 }
 
-function buildExplanation(content: ContentSchemaV1, unitId: string, q: Question): string {
+function buildExplanation(content: ContentSchema, unitId: string, q: Question): string {
   switch (q.type) {
     case "mcq_pinyin": {
       const words = pickWords(content, unitId, q.hanzi);

--- a/src/domain/boss/generate.ts
+++ b/src/domain/boss/generate.ts
@@ -1,5 +1,5 @@
 import { createRng } from "@/domain/rng";
-import type { ContentSchemaV1, Poem, Passage } from "@/domain/content/types";
+import type { ContentSchema, Poem, Passage } from "@/domain/content/types";
 import type { BossMcqQuestion, BossRun } from "@/domain/boss/types";
 
 export type GenerateBossRunOptions = {
@@ -9,7 +9,7 @@ export type GenerateBossRunOptions = {
   questionCount: number; // Boss固定 6
 };
 
-export function generateBossRun(content: ContentSchemaV1, options: GenerateBossRunOptions): BossRun {
+export function generateBossRun(content: ContentSchema, options: GenerateBossRunOptions): BossRun {
   const unit = content.units.find((u) => u.unitId === options.unitId);
   if (!unit) throw new Error(`Unknown unitId: ${options.unitId}`);
 

--- a/src/domain/content/types.ts
+++ b/src/domain/content/types.ts
@@ -6,10 +6,27 @@ export type ContentSchemaV1 = {
   units: Unit[];
 };
 
+
+export type ContentSchemaV2 = {
+  schemaVersion: 2;
+  subject: "chinese";
+  grade: 2;
+  term: "up";
+  units: UnitV2[];
+};
+
+export type ContentSchema = ContentSchemaV1 | ContentSchemaV2;
+
 export type Unit = {
   unitId: string;
   title: string;
   sections: Section[];
+};
+
+export type UnitV2 = {
+  unitId: string;
+  title: string;
+  sections: SectionV2[];
 };
 
 export type Section =
@@ -18,6 +35,15 @@ export type Section =
   | SentencePatternSection
   | PoemSection
   | ReadingComprehensionSection;
+
+export type SectionV2 =
+  | CharTableSection
+  | WordDisambiguationSectionV2
+  | SentencePatternSection
+  | PoemSectionV2
+  | ReadingComprehensionSection
+  | WordListSection
+  | WordPatternsSection;
 
 export type CharTableSection = {
   sectionId: string;
@@ -45,11 +71,25 @@ export type WordDisambiguationSection = {
   items: Array<PolyphoneItem | SynAntItem | ConfusingWordsItem>;
 };
 
+export type WordDisambiguationSectionV2 = {
+  sectionId: string;
+  type: "word_disambiguation";
+  title: string;
+  items: Array<PolyphoneItemV2 | SynAntItem | ConfusingWordsItemV2>;
+};
+
 export type PolyphoneItem = {
   itemId: string;
   kind: "polyphone";
   hanzi: string; // e.g. 教
   options: Array<{ pinyin: string; example: string }>; // e.g. 教书 / 教室
+};
+
+export type PolyphoneItemV2 = {
+  itemId: string;
+  kind: "polyphone";
+  hanzi: string;
+  options: Array<{ pinyin: string; example: string; sentence?: string }>;
 };
 
 export type SynAntItem = {
@@ -66,6 +106,16 @@ export type ConfusingWordsItem = {
   prompt: string;
   correct: string;
   distractors: string[];
+};
+
+export type ConfusingWordsItemV2 = {
+  itemId: string;
+  kind: "confusing";
+  prompt: string;
+  correct: string;
+  distractors: string[];
+  rule?: string;
+  examples?: string[];
 };
 
 // T3 句子仿写（模板 + 词库）
@@ -97,6 +147,36 @@ export type Poem = {
   title: string;
   author: string;
   lines: string[];
+};
+
+export type PoemSectionV2 = {
+  sectionId: string;
+  type: "poem";
+  title: string;
+  poems: PoemV2[];
+};
+
+export type PoemV2 = {
+  poemId: string;
+  title: string;
+  author: string;
+  lines: string[];
+  glossary?: Record<string, string>;
+  meaning?: string;
+};
+
+export type WordListSection = {
+  sectionId: string;
+  type: "word_list";
+  title: string;
+  items: Array<{ itemId: string; word: string; pinyin?: string; tags?: string[] }>;
+};
+
+export type WordPatternsSection = {
+  sectionId: string;
+  type: "word_patterns";
+  title: string;
+  patterns: Array<{ patternId: string; patternType: string; examples: string[]; tags?: string[] }>;
 };
 
 // T5 课文理解（选择/判断）

--- a/src/domain/questions/generate.ts
+++ b/src/domain/questions/generate.ts
@@ -1,6 +1,6 @@
 import { createRng } from "@/domain/rng";
 import type {
-  ContentSchemaV1,
+  ContentSchema,
   CharItem,
   PolyphoneItem,
   SynAntItem,
@@ -32,7 +32,7 @@ export type GenerateRunOptions = {
   shuffleQuestions?: boolean;
 };
 
-export function generateRun(content: ContentSchemaV1, options: GenerateRunOptions): QuizRun {
+export function generateRun(content: ContentSchema, options: GenerateRunOptions): QuizRun {
   const unit = content.units.find((u) => u.unitId === options.unitId);
   if (!unit) throw new Error(`Unknown unitId: ${options.unitId}`);
 

--- a/src/infra/content/localContent.ts
+++ b/src/infra/content/localContent.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
 import content from "@/content/content.v1.json";
-import type { ContentSchemaV1 } from "@/domain/content/types";
+import type { ContentSchema } from "@/domain/content/types";
 
-export function getContent(): ContentSchemaV1 {
+export function getContent(): ContentSchema {
   const raw: unknown = content;
 
   if (typeof raw !== "object" || raw === null) {
@@ -11,9 +11,9 @@ export function getContent(): ContentSchemaV1 {
   }
 
   const schemaVersion = (raw as { schemaVersion?: unknown }).schemaVersion;
-  if (schemaVersion !== 1) {
+  if (schemaVersion !== 1 && schemaVersion !== 2) {
     throw new Error("Unsupported content schema version");
   }
 
-  return raw as ContentSchemaV1;
+  return raw as ContentSchema;
 }


### PR DESCRIPTION
## Summary
- 为内容层引入 `schemaVersion: 2` 的类型定义（v2 提案字段）
- `getContent()` 兼容读取 v1/v2（按 schemaVersion 校验）
- 调整普通关/ Boss 生成器与 `/api/run/check` 接口使用 `ContentSchema` 联合类型

## Notes
- 本 PR 仅做 schema/types/兼容解析打底，不迁移现有 `content.v1.json`
- lint 无 error（有 1 个既有 warning：Dashboard `<img>`）

Closes #19