### PR TITLE
DEV-20260116-017: badge wall + modal + v1 badge set

### DIFF
--- a/src/app/api/run/check/route.ts
+++ b/src/app/api/run/check/route.ts
@@ -4,6 +4,7 @@ import { jsonError, jsonOk } from "@/lib/api";
 import { getAuthedUser } from "@/infra/auth/session";
 import { getSupabaseAdmin } from "@/infra/supabaseAdmin";
 import { getContent } from "@/infra/content/localContent";
+import { computeGrowthBadgeAwards } from "@/domain/badges/rules";
 import { generateRun } from "@/domain/questions/generate";
 import { gradeRun } from "@/domain/questions/grade";
 import type { Answer, Question } from "@/domain/questions/types";
@@ -190,6 +191,23 @@ export async function POST(req: Request) {
           leveledUp,
           xpGained,
         };
+
+        // Growth badges (best-effort)
+        try {
+          const awards = computeGrowthBadgeAwards({ level: nextLevel, xp: nextXp });
+          if (awards.length > 0) {
+            await supabase.from("badge_awards").upsert(
+              awards.map((a) => ({
+                kid_user_id: user.kidUserId,
+                badge_id: a.badgeId,
+                reason_event: a.reasonEvent,
+              })),
+              { onConflict: "kid_user_id,badge_id" },
+            );
+          }
+        } catch {
+          // ignore
+        }
       }
     } catch {
       // ignore

--- a/src/components/dashboard/BadgeModal.tsx
+++ b/src/components/dashboard/BadgeModal.tsx
@@ -1,0 +1,126 @@
+import { BadgeMeta } from "@/domain/badges/catalog";
+import { Button } from "@/components/ui/Button";
+
+interface BadgeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  meta: BadgeMeta;
+  isOwned: boolean;
+  awardedAt?: string;
+  progress?: {
+    current: number;
+    target: number;
+    label?: string;
+  };
+  specialState?: "KP_DISABLED";
+}
+
+export function BadgeModal({
+  isOpen,
+  onClose,
+  meta,
+  isOwned,
+  awardedAt,
+  progress,
+  specialState,
+}: BadgeModalProps) {
+  if (!isOpen) return null;
+
+  const percent = progress
+    ? Math.min(100, Math.max(0, (progress.current / progress.target) * 100))
+    : 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div 
+        className="absolute inset-0 bg-zinc-900/60 backdrop-blur-sm transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* Modal Content */}
+      <div className="relative w-full max-w-sm overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-zinc-200 transition-all sm:max-w-md">
+        {/* Header / Image Area */}
+        <div className={`relative flex h-48 w-full items-center justify-center bg-gradient-to-br ${isOwned ? "from-blue-50 to-indigo-50" : "from-zinc-100 to-zinc-200"}`}>
+          <div className={`relative h-32 w-32 transition-transform duration-700 ${isOwned ? "scale-100" : "scale-90 grayscale opacity-60"}`}>
+            <img
+              src={meta.assetPath}
+              alt={meta.name}
+              className="h-full w-full object-contain drop-shadow-xl"
+              onError={(e) => {
+                e.currentTarget.src = meta.fallbackAssetPath;
+              }}
+            />
+            {/* Lock Overlay for Locked Items */}
+            {!isOwned && !specialState && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="rounded-full bg-zinc-900/20 p-2 backdrop-blur-sm">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white/80">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                  </svg>
+                </div>
+              </div>
+            )}
+             {/* KP Disabled Overlay */}
+             {specialState === "KP_DISABLED" && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                 <div className="rounded-full bg-zinc-800/80 px-3 py-1 text-xs font-bold text-white backdrop-blur-md">
+                   未启用
+                 </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          <div className="mb-1 text-center text-xl font-black text-zinc-900">
+            {meta.name}
+          </div>
+          
+          <div className="mb-6 text-center text-sm text-zinc-500">
+            {specialState === "KP_DISABLED" ? "该徽章暂未启用（需要 KP 统计表数据支持）" : meta.description || "完成特定挑战以解锁此荣誉。"}
+          </div>
+
+          {isOwned ? (
+            <div className="rounded-xl bg-green-50 p-4 text-center ring-1 ring-green-100">
+              <div className="text-xs font-bold uppercase tracking-wider text-green-800">已获得</div>
+              <div className="mt-1 text-sm font-medium text-green-700">
+                {awardedAt ? new Date(awardedAt).toLocaleDateString() : "Unknown Date"}
+              </div>
+            </div>
+          ) : specialState === "KP_DISABLED" ? (
+             <div className="rounded-xl bg-zinc-100 p-4 text-center ring-1 ring-zinc-200">
+              <div className="text-xs font-bold text-zinc-400">系统维护中</div>
+            </div>
+          ) : (
+            <div className="space-y-3 rounded-xl bg-zinc-50 p-4 ring-1 ring-zinc-100">
+              <div className="flex items-center justify-between text-xs font-medium text-zinc-600">
+                <span>当前进度</span>
+                <span>{progress?.current ?? 0} / {progress?.target ?? "?"}</span>
+              </div>
+              
+              <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200">
+                <div 
+                  className="h-full bg-blue-500 transition-all duration-500 ease-out"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+
+              <div className="text-center text-xs text-zinc-400">
+                {progress?.label || "继续努力！"}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-6 flex justify-center">
+            <Button variant="ghost" onClick={onClose} className="text-zinc-500 hover:text-zinc-900">
+              关闭
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -5,8 +5,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
 import { getBadgeMeta } from "@/domain/badges/catalog";
+import type { LevelId } from "@/domain/levels/levels";
 import { LEVELS } from "@/domain/levels/levels";
 import { computeLevelState } from "@/domain/levels/state";
+import { BadgeModal } from "@/components/dashboard/BadgeModal";
 
 type ProgressRow = {
   level_id: string;
@@ -21,6 +23,18 @@ type BadgeRow = {
   awarded_at: string;
   reason_event: string;
 };
+
+type Growth = {
+  xp: number;
+  level: number;
+  title: string;
+  updatedAt: string | null;
+};
+
+type BadgeState =
+  | { status: "unlocked"; earnedAt: string }
+  | { status: "kp_disabled" }
+  | { status: "locked"; progress: { current: number; target: number; label: string } };
 
 // 8 Zones Configuration with Local Assets
 const ZOO_ZONES: Record<string, { name: string; char: string; color: string; pos: string; img: string }> = {
@@ -43,11 +57,27 @@ const CharAvatar = ({ img, alt }: { img: string; alt: string }) => {
   );
 };
 
+// v1 (25 badges): clear(8) + boss_clear(8) + growth_lv(4) + persistence(2) + kp_coverage(3)
+const ALL_BADGES = [
+  ...LEVELS.map((l) => `clear_${l.unitId}`),
+  ...LEVELS.map((l) => `boss_${l.unitId}_clear`),
+  "growth_lv2",
+  "growth_lv3",
+  "growth_lv4",
+  "growth_lv5",
+  "persistence_fails_5",
+  "persistence_fails_10",
+  "kp_coverage_60",
+  "kp_coverage_85",
+  "kp_coverage_100",
+] as const;
 
 export function Dashboard(props: { nickname: string; onLogout: () => void }) {
   const [progress, setProgress] = useState<ProgressRow[]>([]);
   const [badges, setBadges] = useState<BadgeRow[]>([]);
+  const [growth, setGrowth] = useState<Growth | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedBadgeId, setSelectedBadgeId] = useState<string | null>(null);
 
   async function reload() {
     setLoading(true);
@@ -57,6 +87,7 @@ export function Dashboard(props: { nickname: string; onLogout: () => void }) {
       if (json.ok) {
         setProgress(json.data.progress);
         setBadges(json.data.badges);
+        setGrowth(json.data.growth ?? null);
       }
     } finally {
       setLoading(false);
@@ -70,6 +101,68 @@ export function Dashboard(props: { nickname: string; onLogout: () => void }) {
   const levelStates = useMemo(() => {
     return new Map(LEVELS.map((l) => [l.unitId, computeLevelState(l.unitId, progress)]));
   }, [progress]);
+
+  const getBadgeState = (badgeId: string): BadgeState => {
+    const earned = badges.find((b) => b.badge_id === badgeId);
+    if (earned) {
+      return { status: "unlocked", earnedAt: earned.awarded_at };
+    }
+    
+    // KP badges: show disabled (KP tables might not exist)
+    if (badgeId.startsWith("kp_")) return { status: "kp_disabled" };
+
+    // Calculate Progress for Locked
+    let current = 0;
+    let target = 0;
+    let label = "";
+
+    // Parse ID
+    const mClear = badgeId.match(/^clear_(u[1-8])$/);
+    const mBossClear = badgeId.match(/^boss_(u[1-8])_clear$/);
+    
+    if (mClear) {
+      const s = levelStates.get(mClear[1] as LevelId)?.regular?.stars ?? 0;
+      current = s;
+      target = 2;
+      label = "普通关需获2星";
+    } else if (mBossClear) {
+      const s = levelStates.get(mBossClear[1] as LevelId)?.boss?.stars ?? 0;
+      current = s;
+      target = 2;
+      label = "Boss关需获2星";
+    } else if (badgeId === "growth_lv2") {
+      current = growth?.level ?? 1;
+      target = 2;
+      label = "成长到 Lv.2";
+    } else if (badgeId === "growth_lv3") {
+      current = growth?.level ?? 1;
+      target = 3;
+      label = "成长到 Lv.3";
+    } else if (badgeId === "growth_lv4") {
+      current = growth?.level ?? 1;
+      target = 4;
+      label = "成长到 Lv.4";
+    } else if (badgeId === "growth_lv5") {
+      current = growth?.level ?? 1;
+      target = 5;
+      label = "成长到 Lv.5";
+    } else if (badgeId === "persistence_fails_5") {
+      const totalFails = progress.reduce((acc, p) => acc + p.fails, 0);
+      current = totalFails;
+      target = 5;
+      label = "累计失败次数";
+    } else if (badgeId === "persistence_fails_10") {
+      const totalFails = progress.reduce((acc, p) => acc + p.fails, 0);
+      current = totalFails;
+      target = 10;
+      label = "累计失败次数";
+    }
+
+    return { status: "locked", progress: { current, target, label } };
+  };
+
+  const selectedMeta = selectedBadgeId ? getBadgeMeta(selectedBadgeId) : null;
+  const selectedState = selectedBadgeId ? getBadgeState(selectedBadgeId) : null;
 
   return (
     <div className="w-full space-y-8">
@@ -173,49 +266,87 @@ export function Dashboard(props: { nickname: string; onLogout: () => void }) {
       </div>
 
       {/* Badges Section */}
-      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-zinc-200">
-        <div className="mb-4 flex items-center gap-2 border-b border-zinc-100 pb-2">
-          <span className="text-lg font-bold text-zinc-900">警员荣誉墙 (MVP)</span>
-          <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
-            {badges.length} 枚
-          </span>
+      <div className="rounded-3xl bg-white p-8 shadow-xl ring-1 ring-zinc-100">
+        <div className="mb-6 flex items-center justify-between border-b border-zinc-100 pb-4">
+          <div className="flex items-center gap-3">
+             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="8" r="7"></circle><polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88"></polyline></svg>
+             </div>
+             <div>
+                <h2 className="text-lg font-black tracking-tight text-zinc-900">警员荣誉档案</h2>
+                <p className="text-xs text-zinc-500">
+                  已收集 {ALL_BADGES.filter((id) => badges.some((b) => b.badge_id === id)).length} / {ALL_BADGES.length} 枚勋章
+                </p>
+             </div>
+          </div>
         </div>
         
         {loading ? (
-          <div className="py-8 text-center text-sm text-zinc-500">加载档案中...</div>
-        ) : badges.length === 0 ? (
-          <div className="py-8 text-center text-sm text-zinc-500">
-            还没有获得荣誉勋章，快去挑战关卡吧！
-          </div>
+          <div className="py-12 text-center text-sm font-medium text-zinc-400 animate-pulse">正在同步档案数据...</div>
         ) : (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
-            {badges.map((b) => {
-              const meta = getBadgeMeta(b.badge_id);
+          <div className="grid grid-cols-3 gap-4 min-[480px]:grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8">
+            {ALL_BADGES.map((badgeId) => {
+              const meta = getBadgeMeta(badgeId);
+              const state = getBadgeState(badgeId);
+              const isLocked = state.status === "locked";
+              const isKpDisabled = state.status === "kp_disabled";
+
               return (
-                <div key={b.badge_id} className="group relative flex flex-col items-center gap-2 rounded-xl border border-zinc-100 bg-zinc-50 p-3 transition-all hover:bg-white hover:shadow-md">
-                  <div className="relative h-12 w-12 transition-transform group-hover:scale-110">
+                <button
+                  key={badgeId}
+                  onClick={() => setSelectedBadgeId(badgeId)}
+                  className={`group relative flex flex-col items-center gap-2 rounded-2xl p-2 transition-all duration-300 hover:scale-105 hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-blue-500/20
+                    ${isLocked || isKpDisabled ? "opacity-70 grayscale-[0.8]" : "opacity-100 shadow-sm ring-1 ring-zinc-100"}
+                  `}
+                >
+                  <div className="relative aspect-square w-full overflow-hidden rounded-xl">
                     <img
                       src={meta.assetPath}
                       alt={meta.name}
-                      className="h-full w-full object-contain"
+                      className={`h-full w-full object-contain transition-all duration-500 ${isLocked || isKpDisabled ? "scale-90 opacity-60" : "group-hover:scale-110 drop-shadow-md"}`}
                       onError={(e) => {
                         e.currentTarget.src = meta.fallbackAssetPath;
                       }}
                     />
+                    {isLocked && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-black/5 backdrop-blur-[1px]">
+                         <div className="rounded-full bg-white/80 p-1.5 shadow-sm">
+                           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-600"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+                         </div>
+                      </div>
+                    )}
+                    {isKpDisabled && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-zinc-100/50 backdrop-blur-[2px]">
+                         <span className="rounded-md bg-zinc-800 px-1.5 py-0.5 text-[8px] font-bold text-white">
+                           KP待开启
+                         </span>
+                      </div>
+                    )}
                   </div>
-                  <div className="text-center">
-                    <div className="text-xs font-bold text-zinc-900">{meta.name}</div>
-                    <div className="mt-0.5 text-[10px] text-zinc-400">
-                      {new Date(b.awarded_at).toLocaleDateString()}
+                  <div className="w-full text-center">
+                    <div className="truncate text-[10px] font-bold text-zinc-700 group-hover:text-zinc-900">
+                      {meta.name.replace(/\(.*\)/, '')}
                     </div>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>
         )}
       </div>
+
+      {/* Modal */}
+      {selectedBadgeId && selectedMeta && selectedState && (
+        <BadgeModal 
+          isOpen={!!selectedBadgeId}
+          onClose={() => setSelectedBadgeId(null)}
+          meta={selectedMeta}
+          isOwned={selectedState.status === "unlocked"}
+          awardedAt={selectedState.status === "unlocked" ? selectedState.earnedAt : undefined}
+          progress={selectedState.status === "locked" ? selectedState.progress : undefined}
+          specialState={selectedState.status === "kp_disabled" ? "KP_DISABLED" : undefined}
+        />
+      )}
     </div>
   );
 }
-

--- a/src/domain/badges/catalog.ts
+++ b/src/domain/badges/catalog.ts
@@ -13,6 +13,76 @@ const FALLBACK_ASSET = "/badges/badge-placeholder.svg";
 export function getBadgeMeta(badgeId: string): BadgeMeta {
   const assetPath = `/badges/badge-${badgeId}.png`;
 
+  if (badgeId === "growth_lv2") {
+    return {
+      badgeId,
+      name: "见习探员",
+      description: "成长到 Lv.2。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "growth_lv3") {
+    return {
+      badgeId,
+      name: "正式探员",
+      description: "成长到 Lv.3。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "growth_lv4") {
+    return {
+      badgeId,
+      name: "高级探员",
+      description: "成长到 Lv.4。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "growth_lv5") {
+    return {
+      badgeId,
+      name: "王牌探员",
+      description: "成长到 Lv.5。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "kp_coverage_60") {
+    return {
+      badgeId,
+      name: "线索收集者",
+      description: "知识点覆盖率达到 60%（需要 KP 统计表）。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "kp_coverage_85") {
+    return {
+      badgeId,
+      name: "案卷完整",
+      description: "知识点覆盖率达到 85%（需要 KP 统计表）。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
+  if (badgeId === "kp_coverage_100") {
+    return {
+      badgeId,
+      name: "证据链闭环",
+      description: "知识点覆盖率达到 100%（需要 KP 统计表）。",
+      assetPath,
+      fallbackAssetPath: FALLBACK_ASSET,
+    };
+  }
+
   if (badgeId === "persistence_fails_5") {
     return {
       badgeId,

--- a/src/domain/badges/rules.ts
+++ b/src/domain/badges/rules.ts
@@ -35,3 +35,17 @@ export function computeBadgeAwards(ctx: BadgeContext): BadgeAward[] {
 
   return awards;
 }
+
+export function computeGrowthBadgeAwards(input: { level: number; xp: number }): BadgeAward[] {
+  const awards: BadgeAward[] = [];
+
+  if (input.level >= 2) awards.push({ badgeId: "growth_lv2", reasonEvent: "GROWTH_LV2" });
+  if (input.level >= 3) awards.push({ badgeId: "growth_lv3", reasonEvent: "GROWTH_LV3" });
+  if (input.level >= 4) awards.push({ badgeId: "growth_lv4", reasonEvent: "GROWTH_LV4" });
+  if (input.level >= 5) awards.push({ badgeId: "growth_lv5", reasonEvent: "GROWTH_LV5" });
+
+  // KP coverage badges are intentionally NOT awarded here in v1.
+  // They depend on kp_stats tables being present and a coverage calculation.
+
+  return awards;
+}

--- a/src/domain/badges/types.ts
+++ b/src/domain/badges/types.ts
@@ -5,6 +5,13 @@ export type BadgeId =
   | `star3_${UnitId}`
   | `boss_${UnitId}_clear`
   | `boss_${UnitId}_star3`
+  | "growth_lv2"
+  | "growth_lv3"
+  | "growth_lv4"
+  | "growth_lv5"
+  | "kp_coverage_60"
+  | "kp_coverage_85"
+  | "kp_coverage_100"
   | "persistence_fails_5"
   | "persistence_fails_10";
 


### PR DESCRIPTION
## Summary
- Upgrade Dashboard badge wall: show full v1 badge set grid and open details in a modal.
- Locked badges show progress; KP coverage badges show \"未启用\".
- Add growth-level badges awarding in `/api/run/check` (best-effort, requires `kid_growth`).

## v1 Badge Set (25)
- `clear_u1..u8` (regular clear >= ⭐⭐)
- `boss_u1..u8_clear` (boss clear >= ⭐⭐)
- `growth_lv2..growth_lv5`
- `persistence_fails_5`, `persistence_fails_10`
- `kp_coverage_60`, `kp_coverage_85`, `kp_coverage_100` (UI shows disabled)

## Notes
- Badge images are expected at `public/badges/badge-<badgeId>.png` (AI-generated). Until then, fallback placeholder is used.
- Lint has existing `<img>` warnings (no errors).

## Test
- `npm run build`
- `npm run lint` (warnings only)

## How to verify
- Open `/` after login: badge wall shows 25 badges.
- Click any badge: modal opens; locked badges show progress; coverage badges show \"未启用\".